### PR TITLE
Minimize ClassLoader leak with GroovyScriptEngine

### DIFF
--- a/groovy/src/main/java/com/google/code/scriptengines/groovy/GroovyScriptEngineFactory.java
+++ b/groovy/src/main/java/com/google/code/scriptengines/groovy/GroovyScriptEngineFactory.java
@@ -40,6 +40,8 @@ import org.codehaus.groovy.runtime.InvokerHelper;
 
 public class GroovyScriptEngineFactory implements ScriptEngineFactory {
 
+    private static final GroovyScriptEngine SCRIPT_ENGINE = new GroovyScriptEngine();
+
     private static String VERSION = "1.5.6";
     private static List names;
     private static List extensions;
@@ -104,7 +106,7 @@ public class GroovyScriptEngineFactory implements ScriptEngineFactory {
     }
 
     public ScriptEngine getScriptEngine() {
-        return new GroovyScriptEngine();
+        return SCRIPT_ENGINE;
     }
 
     public String getMethodCallSyntax(String obj, String method, String args[]) {


### PR DESCRIPTION
By creating a new instance of `GroovyScriptEngine` each time `GroovyScriptEngineFactory::getScriptEngine` is invoked, new `GroovyClassLoader` is created and new `classMap` class cache is created making every chain of `GroovyScriptEngineFactory::getScriptEngine`,
`GroovyScriptEngine::eval` create new Groovy script class, which for identical scripts over time wastes memory.

This minimises the memory usage, a better solution would be to dispose of the class and the references using `org.codehaus.groovy.runtime.InvokerHelper::removeClass`, but JSR-223 does not provide any lifecycle methods to allow for that.